### PR TITLE
Fix erroneous identity comparison in `UnionFileSystem#newDirStream` and remove redundant checks

### DIFF
--- a/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
+++ b/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
@@ -105,7 +105,6 @@ public class UnionFileSystem extends FileSystem {
         }
     }
     private final UnionPath root = new UnionPath(this, "/");
-    private final UnionPath notExistingPath = new UnionPath(this, "/SNOWMAN");
     private final UnionFileSystemProvider provider;
     private final String key;
     private final List<Path> basepaths;
@@ -254,7 +253,7 @@ public class UnionFileSystem extends FileSystem {
     private Optional<Path> findFirstFiltered(final UnionPath path) {
         for (Path p : this.basepaths) {
             Path realPath = toRealPath(p, path);
-            if (realPath != notExistingPath && testFilter(realPath, p)) {
+            if (testFilter(realPath, p)) {
                 if (realPath.getFileSystem() == FileSystems.getDefault()) {
                     if (realPath.toFile().exists()) {
                         return Optional.of(realPath);
@@ -278,11 +277,9 @@ public class UnionFileSystem extends FileSystem {
             for (Path base : this.basepaths) {
                 // We need to know the full path for the filter
                 Path realPath = toRealPath(base, path);
-                if (realPath != notExistingPath) {
-                    Optional<BasicFileAttributes> fileAttributes = this.getFileAttributes(realPath);
-                        if (fileAttributes.isPresent() && testFilter(realPath, base)) {
-                        return (A) fileAttributes.get();
-                    }
+                Optional<BasicFileAttributes> fileAttributes = this.getFileAttributes(realPath);
+                if (fileAttributes.isPresent() && testFilter(realPath, base)) {
+                    return (A) fileAttributes.get();
                 }
             }
             throw new NoSuchFileException(path.toString());
@@ -346,9 +343,7 @@ public class UnionFileSystem extends FileSystem {
         final var allpaths = new LinkedHashSet<Path>();
         for (final var bp : basepaths) {
             final var dir = toRealPath(bp, path);
-            if (dir == notExistingPath) {
-                continue;
-            } else if (dir.getFileSystem() == FileSystems.getDefault() && !dir.toFile().exists()) {
+            if (dir.getFileSystem() == FileSystems.getDefault() && !dir.toFile().exists()) {
                 continue;
             } else if (dir.getFileSystem().provider().getScheme().equals("jar") && !zipFsExists(this, dir)) {
                 continue;

--- a/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
+++ b/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
@@ -350,7 +350,7 @@ public class UnionFileSystem extends FileSystem {
                 continue;
             } else if (dir.getFileSystem() == FileSystems.getDefault() && !dir.toFile().exists()) {
                 continue;
-            } else if (dir.getFileSystem().provider().getScheme() == "jar" && !zipFsExists(this, dir)) {
+            } else if (dir.getFileSystem().provider().getScheme().equals("jar") && !zipFsExists(this, dir)) {
                 continue;
             } else if (Files.notExists(dir)) {
                 continue;

--- a/src/main/java/cpw/mods/niofs/union/UnionPath.java
+++ b/src/main/java/cpw/mods/niofs/union/UnionPath.java
@@ -231,13 +231,13 @@ public class UnionPath implements Path {
     public Path relativize(final Path other) {
         if (other.getFileSystem()!=this.getFileSystem()) throw new IllegalArgumentException("Wrong filesystem");
         if (other instanceof UnionPath p) {
-            if (this.absolute != p.absolute) {
+            //if (this.absolute != p.absolute) {
                 // Should not be allowed but union fs relies on it
                 // also there is no such concept of a current directory for union paths
                 // meaning absolute and relative paths should have the same effect,
                 // so we just allow this.
                 //throw new IllegalArgumentException("Different types of path");
-            }
+            //}
             var length = Math.min(this.pathParts.length, p.pathParts.length);
             int i = 0;
             while (i < length) {

--- a/src/main/java/net/minecraftforge/securemodules/SecureModuleClassLoader.java
+++ b/src/main/java/net/minecraftforge/securemodules/SecureModuleClassLoader.java
@@ -307,7 +307,7 @@ public class SecureModuleClassLoader extends SecureClassLoader {
         // TODO: [SM] If our parent is null we should look a the bootstrap classloader, but that requires calling super, which will duplicate resources
 
         return new Enumeration<>() {
-            private Enumeration<Enumeration<URL>> itr = Collections.enumeration(results);
+            private final Enumeration<Enumeration<URL>> itr = Collections.enumeration(results);
             private Enumeration<URL> current = findNext();
 
             private Enumeration<URL> findNext() {
@@ -594,7 +594,7 @@ public class SecureModuleClassLoader extends SecureClassLoader {
         });
     }
 
-    private static ModuleReader NOOP_READER = new ModuleReader() {
+    private static final ModuleReader NOOP_READER = new ModuleReader() {
         @Override
         public Optional<URI> find(String name) throws IOException {
             return Optional.empty();

--- a/src/main/java/net/minecraftforge/securemodules/SecureModuleFinder.java
+++ b/src/main/java/net/minecraftforge/securemodules/SecureModuleFinder.java
@@ -80,13 +80,7 @@ public class SecureModuleFinder implements ModuleFinder {
         }
     }
 
-    private static class Reader implements ModuleReader {
-        private final SecureJar.ModuleDataProvider jar;
-
-        public Reader(final SecureJar.ModuleDataProvider jar) {
-            this.jar = jar;
-        }
-
+    private record Reader(SecureJar.ModuleDataProvider jar) implements ModuleReader {
         @Override
         public Optional<URI> find(final String name) throws IOException {
             return jar.findFile(name);


### PR DESCRIPTION
1. `.getScheme() == "jar"` -> `.getScheme().equals("jar")`
2. Remove redundant checks
3. Make a couple of fields final and a static class a record