### PR TITLE
Do not list service providers recursively

### DIFF
--- a/src/main/java/cpw/mods/jarhandling/impl/Jar.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/Jar.java
@@ -282,7 +282,7 @@ public class Jar implements SecureJar {
             return List.of();
 
         try {
-            return Files.walk(services)
+            return Files.list(services)
                 .filter(Files::isRegularFile)
                 .map(path -> getProvider(path, filter))
                 .toList();


### PR DESCRIPTION
Currently, file system providers are listed recursively. This cause issues for some libraries which contain files in sub-folders of `META-INF/services/` that doesn't follow the standard service file format and naming convention.

For example, library `jline-terminal-jansi-3.25.1` has file `META-INF/services/org/jline/terminal/provider/jansi` which causes the following error:
```
Caused by: java.lang.IllegalArgumentException: jansi: is not a qualified name of a Java class in a named package
	at java.base/jdk.internal.module.Checks.requireQualifiedClassName(Checks.java:112)
	at java.base/jdk.internal.module.Checks.requireServiceTypeName(Checks.java:89)
	at java.base/java.lang.module.ModuleDescriptor$Builder.provides(ModuleDescriptor.java:2070)
	at cpw.mods.securejarhandler/cpw.mods.jarhandling.impl.SimpleJarMetadata.lambda$descriptor$1(SimpleJarMetadata.java:22)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(AbstractList.java:722)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at cpw.mods.securejarhandler/cpw.mods.jarhandling.impl.SimpleJarMetadata.descriptor(SimpleJarMetadata.java:22)
	at cpw.mods.securejarhandler/cpw.mods.jarhandling.impl.Jar.computeDescriptor(Jar.java:266)
	at cpw.mods.securejarhandler/cpw.mods.jarhandling.impl.Jar$JarModuleDataProvider.descriptor(Jar.java:416)
	at cpw.mods.securejarhandler/net.minecraftforge.securemodules.SecureModuleFinder$Reference.<init>(SecureModuleFinder.java:56)
	at cpw.mods.securejarhandler/net.minecraftforge.securemodules.SecureModuleFinder.<init>(SecureModuleFinder.java:33)
	at cpw.mods.securejarhandler/net.minecraftforge.securemodules.SecureModuleFinder.of(SecureModuleFinder.java:48)
	at net.minecraftforge.bootstrap@2.1.1/net.minecraftforge.bootstrap.Bootstrap.moduleMain(Bootstrap.java:164)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
```