### PR TITLE
Add `SecureModuleFinder.of(Iterable)`

### DIFF
--- a/src/main/java/cpw/mods/jarhandling/impl/Jar.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/Jar.java
@@ -357,7 +357,7 @@ public class Jar implements SecureJar {
         var ret = new HashSet<String>();
         for (var file : files) {
             int idx = file.lastIndexOf('/');
-            if (!file.endsWith(".class") || idx == -1)
+            if (idx == -1 || !file.endsWith(".class"))
                 continue;
             ret.add(file.substring(0, idx).replace('/', '.'));
         }

--- a/src/main/java/net/minecraftforge/securemodules/SecureModuleFinder.java
+++ b/src/main/java/net/minecraftforge/securemodules/SecureModuleFinder.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 public class SecureModuleFinder implements ModuleFinder {
     private final Map<String, ModuleReference> references = new HashMap<>();
 
-    protected SecureModuleFinder(final SecureJar... jars) {
+    protected SecureModuleFinder(final Iterable<SecureJar> jars) {
         for (var jar : jars) {
             var data = jar.moduleDataProvider();
             if (references.containsKey(data.name()))
@@ -32,6 +32,10 @@ public class SecureModuleFinder implements ModuleFinder {
             else
                 references.put(data.name(), new Reference(data));
         }
+    }
+
+    protected SecureModuleFinder(final SecureJar... jars) {
+        this(Arrays.asList(jars));
     }
 
     @Override
@@ -45,6 +49,10 @@ public class SecureModuleFinder implements ModuleFinder {
     }
 
     public static SecureModuleFinder of(SecureJar... jars) {
+        return new SecureModuleFinder(jars);
+    }
+
+    public static SecureModuleFinder of(Iterable<SecureJar> jars) {
         return new SecureModuleFinder(jars);
     }
 


### PR DESCRIPTION
Allows for providing a reversed view of a collection rather than needing to reverse sort an array. Useful for Bootstrap