### PR TITLE
Fix class loading error when a thread is interrupted

### DIFF
--- a/src/main/java/cpw/mods/jarhandling/impl/Jar.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/Jar.java
@@ -8,13 +8,13 @@ package cpw.mods.jarhandling.impl;
 import cpw.mods.jarhandling.JarMetadata;
 import cpw.mods.jarhandling.SecureJar;
 import cpw.mods.util.LambdaExceptionUtils;
+import cpw.mods.util.ZipUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.lang.module.ModuleDescriptor;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystems;
@@ -196,6 +196,7 @@ public class Jar implements SecureJar {
                     } catch (FileSystemAlreadyExistsException e) {
                         fs = FileSystems.getFileSystem(uri);
                     }
+                    ZipUtils.setUninterruptible(ZipUtils.getByteChannel(fs));
                 } else {
                     // JarInJar is fucking stupid and breaks horribly if it knows about files directly.
                     // So because I don't want to go into the rabbit hole that is digging into that
@@ -215,7 +216,7 @@ public class Jar implements SecureJar {
 
                 fs = UFSP.newFileSystem(base, map);
             }
-        } catch (IOException | URISyntaxException e) {
+        } catch (Throwable e) {
             return sneak(e);
         }
 

--- a/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
+++ b/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
@@ -9,10 +9,6 @@ import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.nio.channels.FileChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.AccessMode;
 import java.nio.file.DirectoryStream;
@@ -42,32 +38,10 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 
-import net.minecraftforge.unsafe.UnsafeHacks;
+import cpw.mods.util.ZipUtils;
 
 public class UnionFileSystem extends FileSystem {
-    private static final MethodHandle ZIPFS_EXISTS;
-    private static final MethodHandle ZIPFS_CH;
-    private static final MethodHandle FCI_UNINTERUPTIBLE;
     static final String SEP_STRING = "/";
-
-    static {
-        try {
-            var hackfield = MethodHandles.Lookup.class.getDeclaredField("IMPL_LOOKUP");
-            UnsafeHacks.setAccessible(hackfield);
-            MethodHandles.Lookup hack = (MethodHandles.Lookup) hackfield.get(null);
-
-            var clz = Class.forName("jdk.nio.zipfs.ZipPath");
-            ZIPFS_EXISTS = hack.findSpecial(clz, "exists", MethodType.methodType(boolean.class), clz);
-
-            clz = Class.forName("jdk.nio.zipfs.ZipFileSystem");
-            ZIPFS_CH = hack.findGetter(clz, "ch", SeekableByteChannel.class);
-
-            clz = Class.forName("sun.nio.ch.FileChannelImpl");
-            FCI_UNINTERUPTIBLE = hack.findSpecial(clz, "setUninterruptible", MethodType.methodType(void.class), clz);
-        } catch (NoSuchFieldException | IllegalAccessException | ClassNotFoundException | NoSuchMethodException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     public InputStream buildInputStream(final UnionPath path) {
         try {
@@ -142,11 +116,9 @@ public class UnionFileSystem extends FileSystem {
     private static Optional<EmbeddedFileSystemMetadata> openFileSystem(final Path path) {
         try {
             var zfs = FileSystems.newFileSystem(path);
-            SeekableByteChannel fci = (SeekableByteChannel) ZIPFS_CH.invoke(zfs);
-            if (fci instanceof FileChannel) { // we only make file channels uninterruptible because byte channels (JIJ) already are
-                FCI_UNINTERUPTIBLE.invoke(fci);
-            }
-            return Optional.of(new EmbeddedFileSystemMetadata(path, zfs, fci));
+            SeekableByteChannel ch = ZipUtils.getByteChannel(zfs);
+            ZipUtils.setUninterruptible(ch);
+            return Optional.of(new EmbeddedFileSystemMetadata(path, zfs, ch));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         } catch (Throwable t) {
@@ -245,7 +217,7 @@ public class UnionFileSystem extends FileSystem {
     private static boolean zipFsExists(UnionFileSystem ufs, Path path) {
         try {
             if (Optional.ofNullable(ufs.embeddedFileSystems.get(path.getFileSystem())).filter(efs->!efs.fsCh.isOpen()).isPresent()) throw new IllegalStateException("The zip file has closed!");
-            return (boolean) ZIPFS_EXISTS.invoke(path);
+            return ZipUtils.exists(path);
         } catch (Throwable t) {
             throw new IllegalStateException(t);
         }

--- a/src/main/java/cpw/mods/util/ZipUtils.java
+++ b/src/main/java/cpw/mods/util/ZipUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package cpw.mods.util;
+
+import net.minecraftforge.unsafe.UnsafeHacks;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.nio.channels.FileChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+
+public class ZipUtils {
+    private static final MethodHandle ZIPFS_EXISTS;
+    private static final MethodHandle ZIPFS_CH;
+    private static final MethodHandle FCI_UNINTERUPTIBLE;
+
+    static {
+        try {
+            var hackfield = MethodHandles.Lookup.class.getDeclaredField("IMPL_LOOKUP");
+            UnsafeHacks.setAccessible(hackfield);
+            MethodHandles.Lookup hack = (MethodHandles.Lookup) hackfield.get(null);
+
+            var clz = Class.forName("jdk.nio.zipfs.ZipPath");
+            ZIPFS_EXISTS = hack.findSpecial(clz, "exists", MethodType.methodType(boolean.class), clz);
+
+            clz = Class.forName("jdk.nio.zipfs.ZipFileSystem");
+            ZIPFS_CH = hack.findGetter(clz, "ch", SeekableByteChannel.class);
+
+            clz = Class.forName("sun.nio.ch.FileChannelImpl");
+            FCI_UNINTERUPTIBLE = hack.findSpecial(clz, "setUninterruptible", MethodType.methodType(void.class), clz);
+        } catch (NoSuchFieldException | IllegalAccessException | ClassNotFoundException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static SeekableByteChannel getByteChannel(final FileSystem zfs) throws Throwable {
+        return (SeekableByteChannel) ZIPFS_CH.invoke(zfs);
+    }
+
+    public static void setUninterruptible(final SeekableByteChannel byteChannel) throws Throwable {
+        if (byteChannel instanceof FileChannel) {
+            FCI_UNINTERUPTIBLE.invoke(byteChannel);
+        }
+    }
+
+    public static boolean exists(final Path path) throws Throwable {
+        return (boolean) ZIPFS_EXISTS.invoke(path);
+    }
+}

--- a/src/main/java/cpw/mods/util/ZipUtils.java
+++ b/src/main/java/cpw/mods/util/ZipUtils.java
@@ -15,6 +15,12 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
 
+/**
+ * Hacky utilities to access interals of ZipFileSystem to prevent thread interrrupts for breaking the entire FileSystem for everyone else.
+ * This is an internal class, not exposed in module-info. If you're using this as a consumer, Don't.
+ * See: https://github.com/MinecraftForge/SecureModules/pull/8
+ * The ZipPath.exists invocation is for a performance optimization. 
+ */
 public class ZipUtils {
     private static final MethodHandle ZIPFS_EXISTS;
     private static final MethodHandle ZIPFS_CH;


### PR DESCRIPTION
When a thread is interrupted while loading a class from disk, the underlying zip filesystem is closed. Any further class loads from the same module will fail.

How to reproduce:
```java
new Thread(() -> {
	Thread.currentThread().interrupt();
	AnyClassNotLoadedYet.class.getName();
}).start();
```
This will result in a `ClassNotFoundException`.

By adding `printStackTrace()` in `SecureModuleClassLoader#findClass(module, name)` I can get the following stacktrace:

```
java.nio.channels.ClosedByInterruptException
	at java.base/java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:200)
	at java.base/sun.nio.ch.FileChannelImpl.endBlocking(FileChannelImpl.java:172)
	at java.base/sun.nio.ch.FileChannelImpl.readInternal(FileChannelImpl.java:992)
	at java.base/sun.nio.ch.FileChannelImpl.read(FileChannelImpl.java:964)
	at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem.readFullyAt(ZipFileSystem.java:1241)
	at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem.readFullyAt(ZipFileSystem.java:1236)
	at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem$EntryInputStream.initDataPos(ZipFileSystem.java:2386)
	at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem$EntryInputStream.read(ZipFileSystem.java:2328)
	at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem$2.fill(ZipFileSystem.java:2278)
	at java.base/java.util.zip.InflaterInputStream.read(InflaterInputStream.java:175)
	at java.base/java.io.InputStream.readNBytes(InputStream.java:412)
	at java.base/java.io.InputStream.readAllBytes(InputStream.java:349)
	at cpw.mods.securejarhandler/net.minecraftforge.securemodules.SecureModuleClassLoader.getClassBytes(SecureModuleClassLoader.java:182)
	at cpw.mods.securejarhandler/cpw.mods.cl.ModuleClassLoader.getClassBytes(ModuleClassLoader.java:38)
	at cpw.mods.securejarhandler/net.minecraftforge.securemodules.SecureModuleClassLoader.readerToClass(SecureModuleClassLoader.java:476)
	at cpw.mods.securejarhandler/net.minecraftforge.securemodules.SecureModuleClassLoader.findClass(SecureModuleClassLoader.java:406)
	at cpw.mods.securejarhandler/net.minecraftforge.securemodules.SecureModuleClassLoader.loadClass(SecureModuleClassLoader.java:423)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	at TRANSFORMER/test_plugin@1.0.0/net.smoofyuniverse.test.TestPlugin.lambda$onServerStarting$1(TestPlugin.java:86)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

This error already existed in the past and was fixed by commit 4e05cab1a822fac008bc4cf74444c768a3fea3db. However it has been fixed only for the union filesystem. Since zip filesystem is currently preferred when possible, this issue still occurs.

~~In this PR, I solve this issue by always preferring the union filesystem, even when there is a single path.~~